### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/obelix_client/__init__.py
+++ b/obelix_client/__init__.py
@@ -22,7 +22,7 @@
 Links
 -----
 
-* `website <http://invenio-software.org/>`_
+* `website <http://inveniosoftware.org/>`_
 * TODO: `documentation <http://********.readthedocs.org/en/latest/>`_
 * `development <https://github.com/inveniosoftware/obelix-client>`_
 """

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     url='https://github.com/inveniosoftware/obelix-client',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     long_description=__doc__,
     packages=['obelix_client'],
     include_package_data=True,


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
